### PR TITLE
Twitch Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ TOKEN=""
 DB_CONNECTION_URL="mongodb+srv://<username>:<password>@<host>?retryWrites=true&w=majority"
 # Twitch Application Client-ID
 TWITCH_CLIENT_ID=""
+TWITCH_CLIENT_SECRET=""
 # Sentry Logging DSN
 SENTRY_DSN=""
 ENVIRONMENT="development"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,5 @@ Check all of the following before merging this PR. If something doesn't apply, i
 
   - [ ] docstrings/dictionaries
   - [ ] `help` command
-  - [ ] [documentation](docs/DOCUMENTATION.md)
+  - [ ] [Documentation](docs/DOCUMENTATION.md)
+  - [ ] [Readme](README.md)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A multi-function Discord Bot made specifically for the NU (Northeastern) Server
     - This is required for the twitch module.
     - Click the "Register Your Application" button.
     - Get the Client-ID from your appilication and replace the `TWITCH_CLIENT_ID` with it in the `.env` file.
+    - Get the Client Secret from your application and replace the `TWITCH_CLIENT_SECRET` with it in the `.env` file.
 7.  Run the application using
     ```sh
     python src/main.py


### PR DESCRIPTION
## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`

- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [x] docstrings/dictionaries
  - [ ] ~`help` command~
  - [ ] ~[documentation](docs/DOCUMENTATION.md)~
  - [x] [Readme](README.md)

Twitch made a breaking change to their API which requires that you make all requests with an Auth Bearer Token. The official change was supposed to be in place as of May 1st, 2020 but they extended it and finally made it mandatory for developers to switch over as of May 11th, 2020.
- The bot was making many requests and was getting 401 Unauthorized requests in this time period and even went down from what's estimated to be 4:17 pm - 6:57 pm on May 12, 2020.
- These changes now make the bot request an Auth Bearer token on startup and then request another one if when making a request there is a 401.