### PR TITLE
Course Enrollment Count

### DIFF
--- a/src/cogs/course_registration/course_cleanup.py
+++ b/src/cogs/course_registration/course_cleanup.py
@@ -1,5 +1,4 @@
 import discord
-import re
 from discord.ext import commands
 
 from checks import is_admin

--- a/src/cogs/course_registration/course_cleanup.py
+++ b/src/cogs/course_registration/course_cleanup.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 
 from checks import is_admin
 from data.ids import COURSE_REGISTRATION_CHANNEL_ID
+from .regex_patterns import IS_COURSE
 
 
 class CourseCleanup(commands.Cog):
@@ -31,8 +32,7 @@ class CourseCleanup(commands.Cog):
             await ctx.send("Goodbye courses...")
             for category in guild.categories:
                 for c in category.text_channels:
-                    pattern = re.compile(r"^[A-Z]{2}([A-Z]{2})?-\d{2}[\dA-Z]{2}$")
-                    if c.topic and pattern.match(c.topic):
+                    if c.topic and IS_COURSE.match(c.topic):
                         await c.edit(
                             overwrites={
                                 guild.default_role: discord.PermissionOverwrite(
@@ -79,11 +79,10 @@ class CourseCleanup(commands.Cog):
         async with ctx.channel.typing():
             for category in guild.categories:
                 for c in category.text_channels:
-                    pattern = re.compile(r"^[A-Z]{2}([A-Z]{2})?-\d{2}[\dA-Z]{2}$")
                     if (
                         not c.overwrites_for(member).is_empty()
                         and c.topic
-                        and pattern.match(c.topic)
+                        and IS_COURSE.match(c.topic)
                     ):
                         await c.set_permissions(member, overwrite=None)
             await ctx.send(f"Done unenrolling {member.name} from all courses!")

--- a/src/cogs/course_registration/course_selection.py
+++ b/src/cogs/course_registration/course_selection.py
@@ -6,6 +6,7 @@ from typing import Optional
 from checks import is_admin, in_channel
 from converters import CaseInsensitiveRoleConverter, CourseChannelConverter
 from data.ids import COURSE_REGISTRATION_CHANNEL_ID, ADMIN_CHANNEL_ID
+from .regex_patterns import IS_COURSE_TOPIC
 
 
 class CourseSelection(commands.Cog):
@@ -39,8 +40,9 @@ class CourseSelection(commands.Cog):
         if not isinstance(after, discord.TextChannel):
             return
 
-        pattern = re.compile(r"^[A-Z]{2}([A-Z]{2})?-\d{2}[\dA-Z]{2} \(\d+ enrolled\)$")
-        if not pattern.match(before.topic) or not pattern.match(after.topic):
+        if not IS_COURSE_TOPIC.match(before.topic) or not IS_COURSE_TOPIC.match(
+            after.topic
+        ):
             return
 
         if before.overwrites == after.overwrites:

--- a/src/cogs/course_registration/create_course.py
+++ b/src/cogs/course_registration/create_course.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from checks import is_admin
 from data.ids import COURSE_REGISTRATION_CHANNEL_ID
-from .regex_patterns import IS_COURSE, IS_COURSE_ACRONYM
+from .regex_patterns import IS_COURSE_ACRONYM
 
 
 class CreateCourse(commands.Cog):

--- a/src/cogs/course_registration/regex_patterns.py
+++ b/src/cogs/course_registration/regex_patterns.py
@@ -1,0 +1,10 @@
+import re
+
+# This checks that an input exactly matches the course format.
+IS_COURSE_ACRONYM = re.compile(r"^[A-Z]{2}([A-Z]{2})?-\d{2}[\dA-Z]{2}$")
+# This checks that a channel is a course channel by making sure it starts with something
+# following the IS_COURSE_ACRONYM pattern. Doesn't exactly matter what comes after.
+IS_COURSE = re.compile(r"^[A-Z]{2}([A-Z]{2})?-\d{2}[\dA-Z]{2}")
+# This should match all course channel topics. Starts with a IS_COURSE pattern
+# and has additional information about how many students are enrolled.
+IS_COURSE_TOPIC = re.compile(r"^[A-Z]{2}([A-Z]{2})?-\d{2}[\dA-Z]{2} \(\d+ enrolled\)$")

--- a/src/converters.py
+++ b/src/converters.py
@@ -10,6 +10,8 @@ from discord.ext.commands import (
 )
 from typing import List, Optional
 
+from cogs.course_registration.regex_patterns import IS_COURSE
+
 
 class CourseChannelConverter(Converter):
     """Converts to a `discord.TextChannel` if a valid course channel is found.
@@ -30,9 +32,8 @@ class CourseChannelConverter(Converter):
         guild: discord.Guild = ctx.guild
         if guild is None:
             raise NoPrivateMessage
-        pattern = re.compile(r"^[A-Z]{2}([A-Z]{2})?-\d{2}[\dA-Z]{2}$")
         # if the role seems to follow a valid course format
-        if pattern.match(argument.upper()) or pattern.match(
+        if IS_COURSE.match(argument.upper()) or IS_COURSE.match(
             argument.replace(" ", "-").upper()
         ):
             if "-" in argument:
@@ -43,7 +44,7 @@ class CourseChannelConverter(Converter):
                 guild.categories, name=course_category
             )
             for c in category.text_channels:
-                if c.topic == f"{course_category}-{course_num}":
+                if c.topic and c.topic.startswith(f"{course_category}-{course_num}"):
                     return c
             raise BadArgument(f'Course "{argument}" not found.')
         raise BadArgument(f'"{argument}" is an invalid course format.')


### PR DESCRIPTION
## Feature Notes
**Problem**: Discord doesn't show the offline members of the number of members in a channel if it's a "large" server. This makes it difficult to discern how many people are enrolled in course channels. Also, there can be members who aren't enrolled in that class but are there anyways (ex: admins and mods). This feature aims to give an accurate count of the number of enrolled members in a course to any member at a glance.
- The number of enrolled students is displayed in the course channel topic next to the name of the course acronym. Ex: "CRSN-1234 (21 enrolled)".
- Since there is code which checks that a channel is a course channel by checking the topic and checking that it's an exact match with a course acronym or at least follows that exact pattern, all those instances have been changed so that it can correctly be identified as a course channel even with the additional information. 

## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`
- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [x] docstrings/dictionaries
  - [ ] ~`help` command~
  - [ ] ~[Documentation](docs/DOCUMENTATION.md)~
  - [ ] ~[Readme](README.md)~
