### PR TITLE
Auto Course Reactions Command

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -59,6 +59,16 @@ Once a member (not a bot) has all 3, the "Not Registered" Role will be removed. 
 **Note:** Will remove all courses from every member and removes all reaction channels for courses. \
 **Purpose:** To initiate a fresh restart for all members and avoid having old members in courses they are not currently taking.
 
+### Auto Course Reactions
+**Command:** `.auto_course_reactions` \
+**Aliases:** `.autoCourseReactions` \
+**Example:** `.auto_course_reactions` \
+**Permissions:** Administrator \
+**Note:** This assumes the format of the course content is like:
+:reaction1: -> Course1 Description (CRSN-1234)\n
+:reaction2: -> Course2 Description (CRSN-4321) \
+**Purpose:** To automate creating course reaction channels if only embeds and content exist. This might happen when a completely new course registration page needs to be made or if resetting the semester also gets rid of all the reaction channels.
+
 ### Clear Courses
 **Command:** `.clear_courses <member>` \
 **Aliases:** `.clearCourses` \

--- a/src/cogs/course_registration/course_cleanup.py
+++ b/src/cogs/course_registration/course_cleanup.py
@@ -66,7 +66,7 @@ class CourseCleanup(commands.Cog):
         """Creates course reaction channels for every course in #course-registration
         automatically just by looking at the course content under each course embedded
         message.
-        The format must be in
+        This assumes the format of the course content is like:
         :reaction1: -> Course1 Description (CRSN-1234)\n
         :reaction2: -> Course2 Description (CRSN-4321)
 

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -218,12 +218,17 @@ class Help(commands.Cog):
         embed = self._get_embed("Course Cleanup")
         embed.add_field(
             name="Commands",
-            value="`.new_semester`, `.clear_courses`, `.clear_reactions`",
+            value="`.new_semester`, `.auto_course_reactions`, `.clear_courses`, `.clear_reactions`",
             inline=False,
         )
         embed.add_field(
             name="new_semester",
             value="Resets course roles and course reaction roles for new semester",
+            inline=False,
+        )
+        embed.add_field(
+            name="auto_course_reactions",
+            value="Creates course reaction channels for everything in course-registration",
             inline=False,
         )
         embed.add_field(
@@ -258,6 +263,33 @@ class Help(commands.Cog):
             value=(
                 "To initiate a fresh restart for all members and avoid "
                 "having old member in courses they are not currently taking."
+            ),
+            inline=False,
+        )
+        await ctx.send(embed=embed)
+
+    @is_admin()
+    @help.group(aliases=["autoCourseReactions"])
+    async def auto_course_reactions(self, ctx: commands.Context) -> None:
+        embed = self._get_embed("auto_course_reactions")
+        embed.add_field(name="Command", value="`.auto_course_reactions`", inline=False)
+        embed.add_field(name="Aliases", value="`.autoCourseReactions`", inline=False)
+        embed.add_field(name="Example", value="`.auto_course_reactions`", inline=False)
+        embed.add_field(
+            name="Note",
+            value=(
+                "This assumes the format of the course content is like:\n"
+                ":reaction1: -> Course1 Description (CRSN-1234)\n"
+                ":reaction2: -> Course2 Description (CRSN-4321)"
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="Purpose",
+            value=(
+                "To automate creating course reaction channels if only embeds and content exist. "
+                "This might happen when a completely new course registration page needs to be made "
+                "or if resetting the semester also gets rid of all the reaction channels."
             ),
             inline=False,
         )

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -29,8 +29,7 @@ class Help(commands.Cog):
     async def help(self, ctx: commands.Context, *, args=None) -> None:
         if args:
             await ctx.send(
-                f"`{args}` is not a recognized option",
-                delete_after=5,
+                f"`{args}` is not a recognized option", delete_after=5,
             )
             return
 


### PR DESCRIPTION
# New Command

## Purpose
- The `new_semester` command removes all reaction channels from course registration in the process of resetting for the semester.
- While this made sense to do before when the course registration usually received a huge rehaul every semester, this time it didn't and re-adding every single course reaction channel (around 150 currently) by hand requires that you associate the reaction, message_id, channel for each course manually and then use the `newrc` command for each case. This would take a long time and is just not fun to do.
- This command was originally just made to be used as an adhoc utility command to fix the issue, but this could also be useful in the future when this state could occur again (while the `new_semester` command will eventually be fixed to make removing all reaction channels automatically this is still a case which could re-occur so no point in re-coding it then)

## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`

- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [x] docstrings/dictionaries
  - [x] `help` command
  - [x] [Documentation](docs/DOCUMENTATION.md)
  - [ ] ~[Readme](README.md)~
