### PR TITLE
Fix Intents Breaking Change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py[voice]==1.4.1
+discord.py[voice]==1.5.1
 pytz
 pymongo[srv]
 python-dotenv

--- a/src/client/setup.py
+++ b/src/client/setup.py
@@ -25,5 +25,6 @@ PREFIX = os.environ.get("PREFIX", ".")
 client = commands.Bot(
     command_prefix=PREFIX,
     allowed_mentions=discord.AllowedMentions(everyone=False, roles=False),
+    intents=discord.Intents.all(),
 )
 client.remove_command("help")


### PR DESCRIPTION
Discord made a breaking change to their API which requires that all bots need to opt-in to certain privelleged intent gateways in order to get member events that were previously available regularly.

The official change was made public September 28th, 2020 and should have been backwards compatible until October 7th, 2020. I thought that compatibility should have been fine as long as discord.py was still on `v.1.4` but Discord might have killed the old gateway and the effects were noticed by me only today (Nov 16th, 2020). Judging by the oldest member that joined with no roles added, this problem occurred at least by October 28th, 2020.

The results caused new members to not be in the cached member list, new member joins and leaves were not detected, and the `NOT_REGISTERED` role was not given to new members causing registration to be a bit off. Members probably weren't receiving information about how to register via their DMs either. More presence information was probably not being received either, but went unnoticed.

## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`

- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [ ] ~docstrings/dictionaries~
  - [ ] ~`help` command~
  - [ ] ~[Documentation](docs/DOCUMENTATION.md)~
  - [ ] ~[Readme](README.md)~
