### PR TITLE
DB client

### DIFF
--- a/src/client/bot.py
+++ b/src/client/bot.py
@@ -1,11 +1,11 @@
 import discord
 import os
-import pymongo
 from collections import defaultdict
 from discord.ext import commands
 from enum import Enum
-from pymongo.collection import Collection
 from typing import Dict, Optional, Union
+
+from .db import DBClient
 
 
 class ChannelType(Enum):
@@ -21,10 +21,8 @@ class Bot(commands.Bot):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.channel_config: Dict[int, Dict[str, int]] = defaultdict(dict)
-        DB_CONNECTION_URL = os.environ["DB_CONNECTION_URL"]
-        mongoClient = pymongo.MongoClient(DB_CONNECTION_URL)
-        guild_configs: Collection = mongoClient.configurator.guild_configs
-        for document in guild_configs.find():
+        self.db = DBClient(os.environ["DB_CONNECTION_URL"])
+        for document in self.db.get_guild_configs():
             guild_id: int = document["guild_id"]
             del document["_id"]
             del document["guild_id"]

--- a/src/client/bot.py
+++ b/src/client/bot.py
@@ -2,19 +2,10 @@ import discord
 import os
 from collections import defaultdict
 from discord.ext import commands
-from enum import Enum
 from typing import Dict, Optional, Union
 
+from .channel_type import ChannelType
 from .db import DBClient
-
-
-class ChannelType(Enum):
-    LOG = "Action Log"
-    HOF = "Hall of Fame"
-    MODMAIL = "Anonymous Modmail"
-    SCHEDULES = "Schedules"
-    SUGGESTIONS = "Suggestions"
-    TWITCH = "Twitch"
 
 
 class Bot(commands.Bot):

--- a/src/client/channel_type.py
+++ b/src/client/channel_type.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class ChannelType(Enum):
+    LOG = "Action Log"
+    HOF = "Hall of Fame"
+    MODMAIL = "Anonymous Modmail"
+    SCHEDULES = "Schedules"
+    SUGGESTIONS = "Suggestions"
+    TWITCH = "Twitch"

--- a/src/client/db.py
+++ b/src/client/db.py
@@ -3,7 +3,7 @@ from pymongo.collection import Collection
 from pymongo.database import Database
 from typing import Optional
 
-from .bot import ChannelType
+from .channel_type import ChannelType
 
 
 class DBClient:

--- a/src/client/db.py
+++ b/src/client/db.py
@@ -70,19 +70,19 @@ class DBClient:
     def get_twitch_tracking_data(self) -> pymongo.CursorType:
         return self.twitch_tracking_data.find()
 
-    def add_twitch_user_data(self, user_data):
+    def start_tracking_twitch_user(self, user_data):
         self.twitch_users.insert_one(user_data)
 
-    def add_twitch_tracking_data(self, tracking_data):
+    def start_tracking_twitch_user_for_guild(self, tracking_data):
         self.twitch_tracking_data.insert_one(tracking_data)
 
-    def remove_twitch_tracking_data(self, twitch_login: str, guild_id: int):
+    def stop_tracking_twitch_user(self, twitch_login: str):
+        self.twitch_users.delete_one({"login": twitch_login})
+
+    def stop_tracking_twitch_user_for_guild(self, twitch_login: str, guild_id: int):
         self.twitch_tracking_data.delete_one(
             {"twitch_login": twitch_login, "guild_id": guild_id}
         )
-
-    def remove_twitch_user(self, twitch_login: str):
-        self.twitch_users.delete_one({"login": twitch_login})
 
     def set_twitch_user_offline(self, twitch_login: str):
         self.twitch_tracking_data.update_one(

--- a/src/client/db.py
+++ b/src/client/db.py
@@ -85,7 +85,7 @@ class DBClient:
         self.twitch_users.delete_one({"login": twitch_login})
 
     def set_twitch_user_offline(self, twitch_login: str):
-        self.twitch_tracking_data.update_mDict(
+        self.twitch_tracking_data.update_one(
             {"twitch_login": twitch_login}, {"$set": {"live_message_id": None}}
         )
 

--- a/src/client/db.py
+++ b/src/client/db.py
@@ -70,10 +70,10 @@ class DBClient:
     def get_twitch_tracking_data(self) -> pymongo.CursorType:
         return self.twitch_tracking_data.find()
 
-    def start_tracking_twitch_user(self, user_data):
+    def start_tracking_twitch_user(self, user_data: dict):
         self.twitch_users.insert_one(user_data)
 
-    def start_tracking_twitch_user_for_guild(self, tracking_data):
+    def start_tracking_twitch_user_for_guild(self, tracking_data: dict):
         self.twitch_tracking_data.insert_one(tracking_data)
 
     def stop_tracking_twitch_user(self, twitch_login: str):
@@ -97,31 +97,31 @@ class DBClient:
             {"$set": {"live_message_id": live_message_id}},
         )
 
-    def find_reaction_channels(self, filter_criteria) -> pymongo.CursorType:
+    def find_reaction_channels(self, filter_criteria: dict) -> pymongo.CursorType:
         return self.reactive_channels.find(filter_criteria)
 
-    def find_one_reaction_channel(self, filter_criteria) -> Optional[dict]:
+    def find_one_reaction_channel(self, filter_criteria: dict) -> Optional[dict]:
         return self.reactive_channels.find_one(filter_criteria)
 
-    def create_reaction_channel(self, data):
+    def create_reaction_channel(self, data: dict):
         self.reactive_channels.insert_one(data)
 
-    def reaction_channel_exists(self, filter_criteria) -> bool:
+    def reaction_channel_exists(self, filter_criteria: dict) -> bool:
         return bool(self.reactive_channels.count_documents(filter_criteria, limit=1))
 
     def remove_reaction_channel(self, key: str):
         self.reactive_channels.delete_one({"key": key})
 
-    def find_reaction_roles(self, filter_criteria) -> pymongo.CursorType:
+    def find_reaction_roles(self, filter_criteria: dict) -> pymongo.CursorType:
         return self.reactive_roles.find(filter_criteria)
 
-    def find_one_reaction_role(self, filter_criteria) -> Optional[dict]:
+    def find_one_reaction_role(self, filter_criteria: dict) -> Optional[dict]:
         return self.reactive_channels.find_one(filter_criteria)
 
-    def create_reaction_role(self, data):
+    def create_reaction_role(self, data: dict):
         self.reactive_roles.insert_one(data)
 
-    def reaction_role_exists(self, filter_criteria) -> bool:
+    def reaction_role_exists(self, filter_criteria: dict) -> bool:
         return bool(self.reactive_roles.count_documents(filter_criteria, limit=1))
 
     def remove_reaction_role(self, key: str):

--- a/src/client/db.py
+++ b/src/client/db.py
@@ -1,0 +1,128 @@
+import pymongo
+from pymongo.collection import Collection
+from pymongo.database import Database
+from typing import Optional
+
+from .bot import ChannelType
+
+
+class DBClient:
+    def __init__(self, db_connection_url: str) -> None:
+        self.db_connection_url: str = db_connection_url
+        self.mongo_client = pymongo.MongoClient(self.db_connection_url)
+
+        self.configurator: Database = self.mongo_client.configurator
+        self.guild_configs: Collection = self.configurator.guild_configs
+
+        self.hall_of_fame: Database = self.mongo_client.hall_of_fame
+        self.hof_sent_messages: Collection = self.hall_of_fame.sent_messages
+        self.hof_blacklist: Collection = self.hall_of_fame.blacklist
+
+        self.twitch: Database = self.mongo_client.twitch
+        self.twitch_users: Collection = self.twitch.twitch_users
+        self.twitch_tracking_data: Collection = self.twitch.twitch_tracking_data
+
+        self.reactions: Database = self.mongo_client.reactions
+        self.reactive_channels: Collection = self.reactions.reactive_channels
+        self.reactive_roles: Collection = self.reactions.reactive_roles
+
+    def get_guild_configs(self) -> pymongo.CursorType:
+        return self.guild_configs.find()
+
+    def configure_channel(
+        self, guild_id: int, channel_type: ChannelType, channel_id: int
+    ):
+        self.configurator.guild_configs.update_one(
+            {"guild_id": guild_id},
+            {"$set": {channel_type.value: channel_id}},
+            upsert=True,
+        )
+
+    def message_in_hof(self, guild_id: int, message_id: int) -> bool:
+        return bool(
+            self.hof_sent_messages.count_documents(
+                {"guild_id": guild_id, "messages": message_id}, limit=1
+            )
+        )
+
+    def add_message_to_hof(self, guild_id: int, message_id: int):
+        self.hof_sent_messages.update_one(
+            {"guild_id": guild_id}, {"$push": {"messages": message_id}}, upsert=True
+        )
+        self.hof_sent_messages.create_index("messages")
+
+    def get_hof_blacklist(self) -> pymongo.CursorType:
+        return self.hof_blacklist.find()
+
+    def add_to_hof_blacklist(self, guild_id: int, channel_id: int):
+        self.hof_blacklist.update_one(
+            {"guild_id": guild_id}, {"$push": {"channels": channel_id}}, upsert=True
+        )
+
+    def remove_from_hof_blacklist(self, guild_id: int, channel_id: int):
+        self.hof_blacklist.update_one(
+            {"guild_id": guild_id}, {"$pull": {"channels": channel_id}}
+        )
+
+    def get_twitch_users(self) -> pymongo.CursorType:
+        return self.twitch_users.find()
+
+    def get_twitch_tracking_data(self) -> pymongo.CursorType:
+        return self.twitch_tracking_data.find()
+
+    def add_twitch_user_data(self, user_data):
+        self.twitch_users.insert_one(user_data)
+
+    def add_twitch_tracking_data(self, tracking_data):
+        self.twitch_tracking_data.insert_one(tracking_data)
+
+    def remove_twitch_tracking_data(self, twitch_login: str, guild_id: int):
+        self.twitch_tracking_data.delete_one(
+            {"twitch_login": twitch_login, "guild_id": guild_id}
+        )
+
+    def remove_twitch_user(self, twitch_login: str):
+        self.twitch_users.delete_one({"login": twitch_login})
+
+    def set_twitch_user_offline(self, twitch_login: str):
+        self.twitch_tracking_data.update_mDict(
+            {"twitch_login": twitch_login}, {"$set": {"live_message_id": None}}
+        )
+
+    def set_twitch_user_live(
+        self, twitch_login: str, guild_id: int, live_message_id: int
+    ):
+        self.twitch_tracking_data.update_one(
+            {"twitch_login": twitch_login, "guild_id": guild_id},
+            {"$set": {"live_message_id": live_message_id}},
+        )
+
+    def find_reaction_channels(self, filter_criteria) -> pymongo.CursorType:
+        return self.reactive_channels.find(filter_criteria)
+
+    def find_one_reaction_channel(self, filter_criteria) -> Optional[dict]:
+        return self.reactive_channels.find_one(filter_criteria)
+
+    def create_reaction_channel(self, data):
+        self.reactive_channels.insert_one(data)
+
+    def reaction_channel_exists(self, filter_criteria) -> bool:
+        return bool(self.reactive_channels.count_documents(filter_criteria, limit=1))
+
+    def remove_reaction_channel(self, key: str):
+        self.reactive_channels.delete_one({"key": key})
+
+    def find_reaction_roles(self, filter_criteria) -> pymongo.CursorType:
+        return self.reactive_roles.find(filter_criteria)
+
+    def find_one_reaction_role(self, filter_criteria) -> Optional[dict]:
+        return self.reactive_channels.find_one(filter_criteria)
+
+    def create_reaction_role(self, data):
+        self.reactive_roles.insert_one(data)
+
+    def reaction_role_exists(self, filter_criteria) -> bool:
+        return bool(self.reactive_roles.count_documents(filter_criteria, limit=1))
+
+    def remove_reaction_role(self, key: str):
+        self.reactive_roles.delete_one({"key": key})

--- a/src/cogs/configurator.py
+++ b/src/cogs/configurator.py
@@ -1,19 +1,11 @@
 import asyncio
 import discord
-import os
-import pymongo
 from discord.ext import commands
 from discord.ext.commands import CategoryChannelConverter, TextChannelConverter
-from pymongo.collection import Collection
 from typing import Callable, Dict, Optional, Tuple, Union
 
 from client.bot import Bot, ChannelType
 from checks import is_admin
-
-
-DB_CONNECTION_URL = os.environ["DB_CONNECTION_URL"]
-mongoClient = pymongo.MongoClient(DB_CONNECTION_URL)
-guild_configs: Collection = mongoClient.configurator.guild_configs
 
 
 class Configurator(commands.Cog):
@@ -219,11 +211,7 @@ class Configurator(commands.Cog):
                     )
                 },
             )
-        guild_configs.update_one(
-            {"guild_id": ctx.guild.id},
-            {"$set": {channel_type.value: channel.id}},
-            upsert=True,
-        )
+        self.client.db.configure_channel(ctx.guild.id, channel_type, channel.id)
         self.client.channel_config[ctx.guild.id][channel_type.value] = channel.id
         embed.set_field_at(
             3, name=field_name, value=channel.name if is_category else channel.mention

--- a/src/cogs/hall_of_fame.py
+++ b/src/cogs/hall_of_fame.py
@@ -156,7 +156,7 @@ class HallOfFame(commands.Cog):
                 guild_id
             )
             embed = discord.Embed(
-                color=discord.Color.red(), timestamp=message.created_at,
+                color=discord.Color.red(), timestamp=message.created_at
             )
             embed.set_author(name=author, icon_url=author.avatar_url)
             attachments: List[discord.Attachment] = message.attachments

--- a/src/cogs/hall_of_fame.py
+++ b/src/cogs/hall_of_fame.py
@@ -1,19 +1,11 @@
-from collections import defaultdict
 import discord
-import os
-import pymongo
+from collections import defaultdict
 from discord.ext import commands
-from pymongo.collection import Collection
 from typing import Dict, List, Optional, Set
 
 from checks import is_admin, is_mod
 from client.bot import Bot, ChannelType
 from utils import required_configs
-
-DB_CONNECTION_URL = os.environ["DB_CONNECTION_URL"]
-mongoClient = pymongo.MongoClient(DB_CONNECTION_URL)
-sent_messages: Collection = mongoClient.hall_of_fame.sent_messages
-hof_blacklist: Collection = mongoClient.hall_of_fame.blacklist
 
 
 class HallOfFame(commands.Cog):
@@ -49,7 +41,7 @@ class HallOfFame(commands.Cog):
         self.hof_emoji: str = "🏆"
         self.mod_hof_emoji: str = "🏅"
         self.hof_blacklist: Dict[int, Set[int]] = defaultdict(set)
-        for document in hof_blacklist.find():
+        for document in self.client.db.get_hof_blacklist():
             guild_id: int = document["guild_id"]
             channels: List[int] = document["channels"]
             self.hof_blacklist[guild_id] = set(channels)
@@ -73,9 +65,7 @@ class HallOfFame(commands.Cog):
         guild: discord.Guild = ctx.guild
         if channel.id in self.hof_blacklist[guild.id]:
             return await ctx.send("This channel is already being blacklisted by HOF.")
-        hof_blacklist.update_one(
-            {"guild_id": guild.id}, {"$push": {"channels": channel.id}}, upsert=True
-        )
+        self.client.db.add_to_hof_blacklist(guild.id, channel.id)
         self.hof_blacklist[guild.id].add(channel.id)
         await ctx.send(f"{channel.mention} has been added to the HOF blacklist")
 
@@ -89,9 +79,7 @@ class HallOfFame(commands.Cog):
             return await ctx.send(
                 "This channel was never blacklisted in the first place"
             )
-        hof_blacklist.update_one(
-            {"guild_id": ctx.guild.id}, {"$pull": {"channels": channel.id}},
-        )
+        self.client.db.remove_from_hof_blacklist(ctx.guild.id, channel.id)
         self.hof_blacklist[ctx.guild.id].remove(channel.id)
         await ctx.send(f"{channel.mention} has been removed from the HOF blacklist")
 
@@ -131,7 +119,7 @@ class HallOfFame(commands.Cog):
             return
 
         message_id: int = payload.message_id
-        if sent_messages.find_one({"guild_id": guild_id, "messages": message_id}):
+        if self.client.db.message_in_hof(guild_id, message_id):
             return
 
         guild: discord.Guild = self.client.get_guild(guild_id)
@@ -183,10 +171,7 @@ class HallOfFame(commands.Cog):
             embed.add_field(name="Jump To", value=f"[Link]({message.jump_url})")
             embed.set_footer(text=f"Message ID: {message_id}")
             await HALL_OF_FAME_CHANNEL.send(embed=embed)
-            sent_messages.update_one(
-                {"guild_id": guild_id}, {"$push": {"messages": message_id}}, upsert=True
-            )
-            sent_messages.create_index("messages")
+            self.client.db.add_message_to_hof(guild_id, message_id)
 
 
 def setup(client: commands.Bot):

--- a/src/cogs/twitch.py
+++ b/src/cogs/twitch.py
@@ -54,12 +54,12 @@ class Twitch(commands.Cog):
             login: str = twitch_user_data["login"]
             self.twitch_login_user_data[login] = twitch_user_data
         for twitch_tracking_data in self.client.db.get_twitch_tracking_data():
-            login = twitch_tracking_data["login"]
+            twitch_login: str = twitch_tracking_data["twitch_login"]
             guild_id: int = twitch_tracking_data["guild_id"]
-            self.guild_to_tracked_logins[guild_id].add(login)
+            self.guild_to_tracked_logins[guild_id].add(twitch_login)
             member_id: Optional[int] = twitch_tracking_data["member_id"]
             live_message_id: Optional[int] = twitch_tracking_data["live_message_id"]
-            self.twitch_tracking_data[login][guild_id] = {
+            self.twitch_tracking_data[twitch_login][guild_id] = {
                 "member_id": member_id,
                 "live_message_id": live_message_id,
             }

--- a/src/cogs/twitch.py
+++ b/src/cogs/twitch.py
@@ -424,14 +424,14 @@ class Twitch(commands.Cog):
                     continue
                 game_name: str = game_response_result.json()["data"][0]["name"]
                 for guild_id, tracking_data in guild_map.items():
-                    twitch_channel: discord.TextChannel = self.client.get_twitch_channel(
-                        guild_id
+                    twitch_channel: discord.TextChannel = (
+                        self.client.get_twitch_channel(guild_id)
                     )
                     live_message_id: Optional[int] = tracking_data["live_message_id"]
                     # edit existing message
                     if live_message_id:
-                        sent_message: discord.Message = await twitch_channel.fetch_message(
-                            live_message_id
+                        sent_message: discord.Message = (
+                            await twitch_channel.fetch_message(live_message_id)
                         )
                         embed_msg: discord.Embed = sent_message.embeds[0]
                         viewer_count: int = int(embed_msg.fields[1].value)
@@ -462,7 +462,9 @@ class Twitch(commands.Cog):
                         if member_id:
                             member: discord.Member = self.client.get_user(member_id)
                             embed.add_field(
-                                name="Member", value=member.mention, inline=True,
+                                name="Member",
+                                value=member.mention,
+                                inline=True,
                             )
                         embed.set_footer(text=f"Stream ID: {stream_id}")
                         sent_message = await twitch_channel.send(embed=embed)

--- a/src/cogs/twitch.py
+++ b/src/cogs/twitch.py
@@ -265,14 +265,14 @@ class Twitch(commands.Cog):
         view_count: int = user_data["view_count"]
 
         if login not in self.twitch_login_user_data:
-            self.client.db.add_twitch_user_data(user_data)
+            self.client.db.start_tracking_twitch_user(user_data)
             self.twitch_login_user_data[login] = user_data
         if login not in self.guild_to_tracked_logins[guild_id]:
             member_and_live_message_data = {
                 "member_id": member_id,
                 "live_message_id": None,
             }
-            self.client.db.add_twitch_tracking_data(
+            self.client.db.start_tracking_twitch_user_for_guild(
                 {
                     "twitch_login": login,
                     "guild_id": ctx.guild.id,
@@ -314,7 +314,7 @@ class Twitch(commands.Cog):
         twitch_login = twitch_login.lower()
 
         if twitch_login in self.guild_to_tracked_logins[guild_id]:
-            self.client.db.remove_twitch_tracking_data(twitch_login, guild_id)
+            self.client.db.stop_tracking_twitch_user_for_guild(twitch_login, guild_id)
             del self.twitch_tracking_data[twitch_login][guild_id]
             self.guild_to_tracked_logins[guild_id].remove(twitch_login)
 
@@ -326,7 +326,7 @@ class Twitch(commands.Cog):
             view_count: int = twitch_user_data["view_count"]
 
             if len(self.twitch_tracking_data[twitch_login]) == 0:
-                self.client.db.remove_twitch_user(twitch_login)
+                self.client.db.stop_tracking_twitch_user(twitch_login)
                 del self.twitch_login_user_data[twitch_login]
 
             await ctx.send(f"Twitch user `{display_name}` stopped being tracked.")


### PR DESCRIPTION
## Problem

Multiple `MongoClient`s were being instantiated across every Cog which needs a database to operate fully. This unnecessarily opens up multiple connections to the database when running. Furthermore, the database logic and business logic of the functions are combined as a result of using the `MongoClient` directly which can make functions difficult to read and tightly coupled.

## Solution

A new `DBClient` is created which is responsible for opening a database connection and providing a simple API to perform all the operations any of the cogs would need to perform with the DB. This `DBClient` is a class variable inside the `Bot` client class which can be accessed from each cog.

This avoids opening a DB connection per cog right off the bat and makes sure all of the logic is constrained inside one wrapper class.

## Additional Bug Fixes
- Fixed typo in `set_twitch_user_offline` function which called `update_mDict` instead of `update_one`
- "login" was changed to "twitch_login" when being accessed from the `twitch_tracking_data` document.

## Results

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/45186928/147703340-1b29238e-676e-4be3-961f-23ce959702e6.png">
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/45186928/147703412-61984ce7-ccae-4392-94b1-b0aea667c646.png">
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/45186928/147703433-eca2ec57-05b8-4df0-a68f-dd790b92c28b.png">

These graphs are the 1 hour metrics where the selected datapoint is approximately when the changes were deployed. For each metric there are 3 graphs where each one represents the metrics of a shard. Opcounters dropped, connections dropped from double digits to 2-3, and network throughput also dropped by 70-80%.

## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`

- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [x] ~~docstrings/dictionaries~~
  - [x] ~~`help` command~~
  - [x] ~~[Documentation](docs/DOCUMENTATION.md)~~
  - [x] ~~[Readme](README.md)~~
