### PR TITLE
Registration change

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,3 @@ ENVIRONMENT="development"
 # WELCOME_CHANNEL_ID=
 # --------------- Test Channel IDs -----------------
 # ERROR_LOG_CHANNEL_ID=
-# --------------- NU Role IDs ----------------------
-# NOT_REGISTERED_ROLE_ID=

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -4,7 +4,6 @@ A member is given the "Not Registered" role on join.
 
 ## Auto-Member Registration Detection and Handling
 A member is required to have the following 3 following types of roles in order to be considered "Registered":
-- **Student**
 - **Year**
   - Freshman
   - Sophomore
@@ -220,7 +219,7 @@ blah blah line 3 blah
 ## Reaction Roles
 ### Adding New Reaction Role
 **Command:** `.newrr <channel> <message_id> <reaction/emoji> <role>` \
-**Example:** `.newrr #rules 123456789876543210 👍 @Student` \
+**Example:** `.newrr #course-registration 123456789876543210 💻 @CCIS` \
 **Permissions:** Administrator \
 **Purpose:** Allows for the user to select a specific message that users can react to with a chosen emoji to get assigned a role and unreact to remove the role.
 

--- a/src/cogs/configurator.py
+++ b/src/cogs/configurator.py
@@ -40,7 +40,6 @@ class Configurator(commands.Cog):
                 - Welcome Channel
                 - Rules Channel
                 - Not Registered Channel
-                - Not Registered Role
             - Registration:
                 - Course Registration Channel
                 - Choose Notification Channel (ADMIN_CHANNEL_ID)

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -904,7 +904,7 @@ class Help(commands.Cog):
         )
         embed.add_field(
             name="Example",
-            value="`.newrr #rules 123456789876543210 👍 @Student`",
+            value="`.newrr #course-registration 123456789876543210 💻 @CCIS`",
             inline=False,
         )
         embed.add_field(

--- a/src/cogs/stats.py
+++ b/src/cogs/stats.py
@@ -33,15 +33,13 @@ class Stats(commands.Cog):
         Note: A New Account is considered to be an account which was created within 1 day of joining the server.
         """
         guild: discord.Guild = ctx.guild
-        NOT_REGISTERED: discord.Role = discord.utils.get(
-            guild.roles, name="Not Registered"
+        REGISTERED_ROLE: discord.Role = discord.utils.get(
+            guild.roles, name="Registered"
         )
         new_accounts: int = Counter(
             [(m.joined_at - m.created_at).days <= 1 for m in guild.members]
         )[True]
-        not_registered_count: int = Counter(
-            [NOT_REGISTERED in m.roles for m in guild.members]
-        )[True]
+        not_registered_count: int = guild.member_count - len(REGISTERED_ROLE.members)
         num_bots: int = Counter([m.bot for m in guild.members])[True]
         statuses = Counter([(m.status, m.is_on_mobile()) for m in guild.members])
         online_mobile: int = statuses[(discord.Status.online, True)]

--- a/src/data/ids.py
+++ b/src/data/ids.py
@@ -14,5 +14,3 @@ RULES_CHANNEL_ID = int(os.getenv("RULES_CHANNEL_ID", 485279439593144362))
 WELCOME_CHANNEL_ID = int(os.getenv("WELCOME_CHANNEL_ID", 557325274534903815))
 # --------------- Test Channel IDs -----------------
 ERROR_LOG_CHANNEL_ID = int(os.getenv("ERROR_LOG_CHANNEL_ID", 685752035806806047))
-# --------------- NU Role IDs ----------------------
-NOT_REGISTERED_ROLE_ID = int(os.getenv("NOT_REGISTERED_ROLE_ID", 501184186498154511))


### PR DESCRIPTION
## Problem
Discord's permission and moderation system was designed around the idea that members without any roles would be restricted, however, as soon as a member has any role everything is ignored. This means that a server's moderation verification level is completely ignored and the new Membership Screening feature is also bypassed.

Currently, new members are given a Not Registered role upon joining which nullifies all of this.

## Solution
In order to take advantage of these in-built features, registration will not assign a role immediately upon join, but instead will assign a "Registered" role when a member has successfully registered.

Also, since the new Membership Screening can be used now, the requirement that people react with a 👍 emoji to get the Student role and make that part of the verification process is no longer necessary.

## Pre-Merge Steps
- [x] Create a role called "Registered"
- [x] Disable the #rules and #course-registration channels for anyone to prevent registration statuses to change midway during this process.
- [x] Run an-adhoc script in order to assign the "Registered" role to all members who do not have the "Not Registered" role attached to them. It is important to do this before merge in order to avoid the registration DMs being sent to every member.
-  [x] Channels which simply exclude "Not Registered" role members need to change to only include "Registered" role members.
-  [x] The #not-registered-help channel should change from only allowing people with the Not Registered role to allow everyone except those with the Registered Role.
- [x] The reaction role from #rules which was associated with the 👍 emoji should be deleted using `.removerr`.
- [x] Re-open the #rules and #course-registration channels

## Post-Merge Steps
- [x] The Not Registered role can safely be deleted.
- [x] The Student role can safely be deleted.

## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`

- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [x] docstrings/dictionaries
  - [x] `help` command
  - [x] [Documentation](docs/DOCUMENTATION.md)
  - [x] [Readme](README.md)
