### PR TITLE
Course registration new semester

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -76,6 +76,13 @@ Once a member (not a bot) has all 3, the "Not Registered" Role will be removed. 
 **Note:** Will remove all courses from a member. \
 **Purpose:** Allows for easy unerollment from all courses for a member, useful when either starting a new semester or in cases of spam.
 
+### Clear Courses
+**Command:** `.clone_cr` \
+**Example:** `.clone_cr` \
+**Permissions:** Administrator \
+**Note:** Will clone all the embeds and associated course decription message in whatever channel the command was invoked from. \
+**Purpose:** Main use-case is when a new semester requires a cleanup/rehaul.
+
 ### Clear Reactions
 **Command:** `.clear_reactions <member>` \
 **Aliases:** `.clearReactions` \

--- a/src/client/bot.py
+++ b/src/client/bot.py
@@ -1,5 +1,6 @@
 import discord
 import os
+import requests
 from collections import defaultdict
 from discord.ext import commands
 from typing import Dict, Optional, Union
@@ -18,6 +19,8 @@ class Bot(commands.Bot):
             del document["_id"]
             del document["guild_id"]
             self.channel_config[guild_id] = document
+        EMOJI_JSON_URL = "https://gist.githubusercontent.com/Vexs/629488c4bb4126ad2a9909309ed6bd71/raw/da8c23f4a42f3ad7cf829398b89bda5347907fef/emoji_map.json"
+        self.emoji_map: Dict[str, str] = requests.get(EMOJI_JSON_URL).json()
 
     def _get_channel(
         self, guild_id: int, channel_type: ChannelType

--- a/src/cogs/course_registration/course_cleanup.py
+++ b/src/cogs/course_registration/course_cleanup.py
@@ -1,5 +1,8 @@
+import asyncio
 import discord
+import string
 from discord.ext import commands
+from typing import List, Tuple
 
 from checks import is_admin
 from client.bot import Bot
@@ -109,6 +112,58 @@ class CourseCleanup(commands.Cog):
                             target_channel,
                         )
         await ctx.send("All reaction channels were added back for courses!")
+
+    @is_admin()
+    @commands.guild_only()
+    @commands.command()
+    async def clone_cr(self, ctx: commands.Context) -> None:
+        """Duplicates course embeds and contents in sorted category order and assigning
+        emojis in alphabetical order in terms of the course order.
+
+        Parameters
+        ------------
+        ctx: `commands.Context`
+            A class containing metadata about the command invocation.
+        """
+        guild: discord.Guild = ctx.guild
+        COURSE_REGISTRATION_CHANNEL: discord.TextChannel = guild.get_channel(
+            COURSE_REGISTRATION_CHANNEL_ID
+        )
+        messages = await COURSE_REGISTRATION_CHANNEL.history(
+            limit=None, oldest_first=True
+        ).flatten()
+        category_messages: List[Tuple[str, discord.Embed, discord.Message]] = []
+        for index, message in enumerate(messages):
+            if message.embeds:
+                embed_msg: discord.Embed = message.embeds[0]
+                embed_title: str = str(embed_msg.title)
+                if "Add/Remove" in embed_title:
+                    category_name: str = embed_title.split()[1]
+                    category_messages.append(
+                        (category_name, embed_msg, messages[index + 1])
+                    )
+
+        category_messages.sort(key=lambda m: m[0])
+        for category_name, embed, msg in category_messages:
+            new_embed_cmd: commands.Command = self.client.get_command("new_embed")
+            await ctx.invoke(
+                new_embed_cmd,
+                embed.image.url,
+                title=f"Add/Remove {category_name} courses",
+            )
+            lines: List[str] = msg.content.split("\n")
+            for index, line in enumerate(lines):
+                course_desc: str = line.split(" -> ")[-1]
+                lines[
+                    index
+                ] = f":regional_indicator_{string.ascii_lowercase[index]}: -> {course_desc}"
+
+            content: str = "\n".join(lines)
+            await ctx.send(content)
+            # quick and dirty way to ensure to some degree that embeds are created in order
+            asyncio.sleep(5)
+
+        await ctx.send("Cloning complete!")
 
     @is_admin()
     @commands.guild_only()

--- a/src/cogs/course_registration/course_content.py
+++ b/src/cogs/course_registration/course_content.py
@@ -53,7 +53,11 @@ class CourseContent(commands.Cog):
         title: `str`
             The title of the embed to set.
         """
-        await ctx.message.delete()
+        try:
+            await ctx.message.delete()
+        except discord.errors.NotFound:
+            # if invoked from another command the message may not be there to delete anymore
+            pass
         try:
             await self._send_new_embed(ctx, title, img_url)
         except discord.errors.HTTPException:

--- a/src/cogs/course_registration/create_course.py
+++ b/src/cogs/course_registration/create_course.py
@@ -27,20 +27,20 @@ class CreateCourse(commands.Cog):
     async def new_course(
         self, ctx: commands.Context, name: str, *, channel_name: str
     ) -> bool:
-        """Creates a new course channel and role if one does not already exist.
+        """Creates a new course channel if one does not already exist.
 
         Parameters
         -----------
         ctx: `commands.Context`
             A class containing metadata about the command invocation.
         name: `str`
-            The course acronym and the role name.
+            The course acronym.
         channel_name: `str`
             The name of the channel.
 
         Returns
         -----------
-        True if both the channel and role were created succesfully, else False.
+        True if the channel was created succesfully, else False.
         """
         name = name.upper()
         if not IS_COURSE_ACRONYM.match(name):
@@ -100,7 +100,7 @@ class CreateCourse(commands.Cog):
     async def new_course_reaction(
         self, ctx: commands.Context, course_abbr: str, *, course_name: str
     ) -> bool:
-        """Creates a reaction role for the course.
+        """Creates a reaction channel for the course.
         Will also edit the message for course description lists under the embedded message.
 
         Parameters
@@ -110,11 +110,11 @@ class CreateCourse(commands.Cog):
         course_abbr: `str`
             The course abbreviation as category acronym and course number divided with a dash.
         course_name:  `str`
-            The name of the course to be added in the course reaction role description.
+            The name of the course to be added in the course reaction channel description.
 
         Returns
         -----------
-        True if the reaction role for the course was created successfully, else False.
+        True if the reaction channel for the course was created successfully, else False.
         """
         guild: discord.Guild = ctx.guild
         COURSE_REGISTRATION_CHANNEL: discord.TextChannel = guild.get_channel(
@@ -147,7 +147,7 @@ class CreateCourse(commands.Cog):
                     content: str = description_message.content
                     if str(course_num) in content:
                         await ctx.send(
-                            f"The given course already has a reaction role setup in {COURSE_REGISTRATION_CHANNEL.mention}"
+                            f"The given course already has a reaction channel setup in {COURSE_REGISTRATION_CHANNEL.mention}"
                         )
                         return False
 
@@ -158,7 +158,7 @@ class CreateCourse(commands.Cog):
                     ]
                     # check to see if this message has reached it's reaction limit
                     # if so continue to search for another message, otherwise break
-                    # now and add a reaction role here
+                    # now and add a reaction here
                     try:
                         await message.add_reaction(emoji)
                         await message.remove_reaction(emoji, self.client.user)
@@ -195,11 +195,11 @@ class CreateCourse(commands.Cog):
         category: discord.CategoryChannel = discord.utils.get(
             guild.categories, name=course_category
         )
-        reaction_role_command: commands.Command = self.client.get_command("newrc")
+        reaction_channel_command: commands.Command = self.client.get_command("newrc")
         for c in category.text_channels:
             if c.topic and c.topic.startswith(course_abbr):
                 await ctx.invoke(
-                    reaction_role_command,
+                    reaction_channel_command,
                     *[COURSE_REGISTRATION_CHANNEL, message.id, emoji, c],
                 )
                 return True
@@ -209,16 +209,16 @@ class CreateCourse(commands.Cog):
     @commands.guild_only()
     @commands.command(aliases=["newCourseComplete"])
     async def new_course_complete(
-        self, ctx: commands.Context, course_role_name: str, *, descriptions: str
+        self, ctx: commands.Context, course_name: str, *, descriptions: str
     ) -> None:
-        """Creates a role, channel, and reaction role for the course.
+        """Creates a channel and reaction channel for the course.
 
         Parameters
         ------------
         ctx: `commands.Context`
             A class containing metadata about the command invocation.
-        course_role_name: `str`
-            The name of the role associated with the course.
+        course_name: `str`
+            The name of the course.
         description: `str`
             A comma separated string containing the channel name in the first half
             and the course description in the second.
@@ -233,10 +233,8 @@ class CreateCourse(commands.Cog):
             await ctx.send("Your channel & course description must have content")
             return
 
-        if await self.new_course(ctx, course_role_name, channel_name=channel_name):
-            await self.new_course_reaction(
-                ctx, course_role_name, course_name=course_name
-            )
+        if await self.new_course(ctx, course_name, channel_name=channel_name):
+            await self.new_course_reaction(ctx, course_name, course_name=course_name)
 
 
 def setup(client: commands.Bot):

--- a/src/cogs/course_registration/create_course.py
+++ b/src/cogs/course_registration/create_course.py
@@ -74,19 +74,21 @@ class CreateCourse(commands.Cog):
 
             # create and insert the channel in order
             channel: discord.TextChannel = await category.create_text_channel(
-                channel_name, overwrites=channel_overwrites, reason="New course",
+                channel_name, overwrites=channel_overwrites, reason="New course"
             )
+            await channel.edit(topic=f"{name} (0 enrolled)")
             if len(category.channels) > 1:
                 for c in category.channels:
                     course_name = c.topic
-                    curr_course_num = int(
-                        re.sub(r"\D", "0", course_name.split("-")[1][:4])
-                    )
-                    channel_position: int = c.position
-                    if course_num > curr_course_num:
-                        await channel.edit(position=channel_position)
-                        break
-            await channel.edit(topic=f"{name} (0 enrolled)")
+                    # sometimes the newly created channel's topic is None so ignore it
+                    if course_name:
+                        curr_course_num = int(
+                            re.sub(r"\D", "0", course_name.split("-")[1][:4])
+                        )
+                        channel_position: int = c.position
+                        if course_num > curr_course_num:
+                            await channel.edit(position=channel_position)
+                            break
             await ctx.send(
                 f"A channel named `{channel_name}` was created in the `{category.name}` category."
             )

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -218,7 +218,7 @@ class Help(commands.Cog):
         embed = self._get_embed("Course Cleanup")
         embed.add_field(
             name="Commands",
-            value="`.new_semester`, `.auto_course_reactions`, `.clear_courses`, `.clear_reactions`",
+            value="`.new_semester`, `.auto_course_reactions`, `.clone_cr`, `.clear_courses`, `.clear_reactions`",
             inline=False,
         )
         embed.add_field(
@@ -229,6 +229,11 @@ class Help(commands.Cog):
         embed.add_field(
             name="auto_course_reactions",
             value="Creates course reaction channels for everything in course-registration",
+            inline=False,
+        )
+        embed.add_field(
+            name="clone_cr",
+            value="Clones course-registration embeds and associated course description messages",
             inline=False,
         )
         embed.add_field(
@@ -290,6 +295,28 @@ class Help(commands.Cog):
                 "To automate creating course reaction channels if only embeds and content exist. "
                 "This might happen when a completely new course registration page needs to be made "
                 "or if resetting the semester also gets rid of all the reaction channels."
+            ),
+            inline=False,
+        )
+        await ctx.send(embed=embed)
+
+    @is_admin()
+    async def auto_course_reactions(self, ctx: commands.Context) -> None:
+        embed = self._get_embed("clone_cr")
+        embed.add_field(name="Command", value="`.clone_cr`", inline=False)
+        embed.add_field(name="Example", value="`.clone_cr`", inline=False)
+        embed.add_field(
+            name="Note",
+            value=(
+                "Will clone all the embeds and associated course decription message "
+                "in whatever channel the command was invoked from."
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="Purpose",
+            value=(
+                "Main use-case is when a new semester requires a cleanup/rehaul."
             ),
             inline=False,
         )


### PR DESCRIPTION
## Problem
- After exhausting A-Z for reactions for a course category, there is no way to continue
- There is no easy way to replicate new course embeds in order for a new semester without deleting everything and re-creating them manually.
- There were also some misc bugs which exist when trying to create a new course

## Solution
- Always start from the reaction A on every course embed even if it's the 2nd part of a multi-part embed.
- Create a `.clone_cr` command which clones the embeds in alphabetical order and assigns the new emojis for each course associated by order presented in the description
- Fix bugs which had to do with unhandled exceptions

## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`

- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [x] docstrings/dictionaries
  - [x] `help` command
  - [x] [Documentation](docs/DOCUMENTATION.md)
  - [x] [Readme](README.md)
