### PR TITLE
Ignore pfp changes for bots

### DIFF
--- a/src/cogs/logs.py
+++ b/src/cogs/logs.py
@@ -183,6 +183,9 @@ class Logs(commands.Cog):
         after: `discord.User`
             The user object after the update.
         """
+        if before.bot:
+            return
+
         if before.avatar_url != after.avatar_url:
             action_log_channels: List[discord.TextChannel] = []
             for guild in after.mutual_guilds:

--- a/src/cogs/logs.py
+++ b/src/cogs/logs.py
@@ -99,7 +99,7 @@ class Logs(commands.Cog):
                         )
 
             embed.add_field(
-                name="Sent At", value=est_sent.strftime("%x %I:%M%p"), inline=False,
+                name="Sent At", value=est_sent.strftime("%x %I:%M%p"), inline=False
             )
             embed.set_footer(text=f"ID: {message.id}")
             await ACTION_LOG_CHANNEL.send(embed=embed)
@@ -232,7 +232,7 @@ class Logs(commands.Cog):
         utc_joined_at: datetime = timezone("UTC").localize(member.joined_at)
         est_joined_at: datetime = utc_joined_at.astimezone(timezone("US/Eastern"))
         log_msg.add_field(
-            name="Joined At", value=est_joined_at.strftime("%x %I:%M%p"), inline=False,
+            name="Joined At", value=est_joined_at.strftime("%x %I:%M%p"), inline=False
         )
         log_msg.set_footer(text=f"Member ID: {member.id}")
 


### PR DESCRIPTION
## Problem

There is a bot which changes it's profile picture almost every 5-10 minutes. This causes immense spam in logs which aren't actually necessary to monitor anyways.

## Solution
Ignore any user change events from bots as they do not need to be logged/monitored. This is acceptable because:
1. Most servers usually don't have many bots and it's not hard to detect changes manually.
2. Most bots are not changing their profile picture frequently, and it's quite easy to figure out when it happens if there is any action to be taken.
3. Any bots which do change profile pictures frequently is also easily found out and adds more noise than helpful information which prevents logs from being useful and easy to scan through.

## Merge Checklist ##
Check all of the following before merging this PR. If something doesn't apply, indicate this by ~striking out~ with `~`

- [x] Test each changed feature
- [x] Any commented out cogs, temporary commands, debug statements, etc are reverted.

- Any changes to signatures/available location are reflected in:

  - [x] ~~docstrings/dictionaries~~
  - [x] ~~`help` command~~
  - [x] ~~[Documentation](docs/DOCUMENTATION.md)~~
  - [x] ~~[Readme](README.md)~~
